### PR TITLE
Elastic Search Scienti.

### DIFF
--- a/HunabKu_scienti/hunabku_scienti/_version.py
+++ b/HunabKu_scienti/hunabku_scienti/_version.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-__version__ = '0.0.6'
+__version__ = '0.0.7'
 
 def get_version():
     return __version__

--- a/HunabKu_scienti/hunabku_scienti/endpoints/Scienti.py
+++ b/HunabKu_scienti/hunabku_scienti/endpoints/Scienti.py
@@ -287,6 +287,7 @@ class Scienti(HunabkuPluginBase):
         @apiParam {String} model_year  year of the scienti model, example: 2022
         @apiParam {String} institution institution initials. supported example: udea, uec, unaula, univalle
         @apiParam {String} search Allows to search text keywords in several fields of the network collection using elastic search.
+        @apiParam {String} group_id  Returns networks for the given group id.
 
         @apiSuccess {Object}  Resgisters from MongoDB in Json format.
 
@@ -302,6 +303,9 @@ class Scienti(HunabkuPluginBase):
             curl -i http://apis.colav.co/scienti/network?apikey=XXXX&model_year=2022&institution=udea&SGL_CATEGORIA=RC-RC_A
             # Text search for a keyword using elastic search
             curl -i http://apis.colav.co/scienti/network?apikey=XXXX&model_year=2022&institution=udea&search="educación"
+            # return networks for the given group id
+            curl -i http://apis.colav.co/scienti/network?apikey=XXXX&model_year=2022&institution=udea&group_id=COL0053803
+
         """
 
         if self.valid_apikey():
@@ -311,12 +315,13 @@ class Scienti(HunabkuPluginBase):
             model_year = self.request.args.get('model_year')
             institution = self.request.args.get('institution')
             keyword = self.request.args.get('search')
+            group_id = self.request.args.get('group_id')
 
             response = self.check_required_parameters(self.request.args)
             if response is not None:
                 return response
             response = self.check_parameters(
-                ['apikey', 'COD_RH', 'COD_RED', 'SGL_CATEGORIA', 'model_year', 'institution', 'search'], self.request.args.keys())
+                ['apikey', 'COD_RH', 'COD_RED', 'SGL_CATEGORIA', 'model_year', 'institution', 'search', 'group_id'], self.request.args.keys())
             if response is not None:
                 return response
 
@@ -411,6 +416,16 @@ class Scienti(HunabkuPluginBase):
                         mimetype='application/json'
                     )
                     return response
+                if group_id:
+                    data = list(self.db["network"].find(
+                        {'group.COD_ID_GRUPO': group_id}, {"_id": 0}))
+                    response = self.app.response_class(
+                        response=self.json.dumps(data),
+                        status=200,
+                        mimetype='application/json'
+                    )
+                    return response
+
                 data = {
                     "error": "Bad Request", "message": "invalid parameters, please select the right combination of parameters"}
                 response = self.app.response_class(

--- a/HunabKu_scienti/hunabku_scienti/endpoints/Scienti.py
+++ b/HunabKu_scienti/hunabku_scienti/endpoints/Scienti.py
@@ -627,6 +627,7 @@ class Scienti(HunabkuPluginBase):
         @apiParam {String} model_year  year of the scienti model, example: 2022
         @apiParam {String} institution institution initials. supported example: udea, uec, unaula, univalle
         @apiParam {String} search Allows to search text keywords in several fields of the event collection using elastic search.
+        @apiParam {String} group_id  Returns events for the given group id.
 
         @apiSuccess {Object}  Resgisters from MongoDB in Json format.
 
@@ -642,6 +643,8 @@ class Scienti(HunabkuPluginBase):
             curl -i http://apis.colav.co/scienti/event?apikey=XXXX&model_year=2022&institution=udea&SGL_CATEGORIA=EC-EC_B
             # Text search for a keyword using elastic search
             curl -i http://apis.colav.co/scienti/event?apikey=XXXX&model_year=2022&institution=udea&search="machine learning"
+            # return event for the given group id
+            curl -i http://apis.colav.co/scienti/event?apikey=XXXX&model_year=2022&institution=udea&group_id=COL0008423
 
         """
         if self.valid_apikey():
@@ -651,12 +654,13 @@ class Scienti(HunabkuPluginBase):
             model_year = self.request.args.get('model_year')
             institution = self.request.args.get('institution')
             keyword = self.request.args.get('search')
+            group_id = self.request.args.get('group_id')
 
             response = self.check_required_parameters(self.request.args)
             if response is not None:
                 return response
             response = self.check_parameters(
-                ['apikey', 'COD_RH', 'COD_PROYECTO', 'COD_EVENTO', 'model_year', 'institution', 'search'], self.request.args.keys())
+                ['apikey', 'COD_RH', 'COD_PROYECTO', 'COD_EVENTO', 'model_year', 'institution', 'search', 'group_id'], self.request.args.keys())
             if response is not None:
                 return response
 
@@ -739,6 +743,16 @@ class Scienti(HunabkuPluginBase):
                         mimetype='application/json'
                     )
                     return response
+                if group_id:
+                    data = list(self.db["event"].find(
+                        {'group.COD_ID_GRUPO': group_id}, {"_id": 0}))
+                    response = self.app.response_class(
+                        response=self.json.dumps(data),
+                        status=200,
+                        mimetype='application/json'
+                    )
+                    return response
+
                 data = {
                     "error": "Bad Request", "message": "invalid parameters, please select the right combination of parameters"}
                 response = self.app.response_class(

--- a/HunabKu_scienti/hunabku_scienti/endpoints/Scienti.py
+++ b/HunabKu_scienti/hunabku_scienti/endpoints/Scienti.py
@@ -107,6 +107,7 @@ class Scienti(HunabkuPluginBase):
         @apiParam {String} model_year  Year of the scienti model, example: 2022
         @apiParam {String} institution Institution initials. supported example: udea, uec, unaula, univalle
         @apiParam {String} search Allows to search text keywords in several fields of the product collection using elastic search.
+        @apiParam {String} group_id  Group id.
 
 
         @apiSuccess {Object}  Resgisters from MongoDB in Json format.
@@ -123,6 +124,8 @@ class Scienti(HunabkuPluginBase):
             curl -i http://apis.colav.co/scienti/product?apikey=XXXX&model_year=2022&institution=udea&SGL_CATEGORIA=ART-ART_A1
             # Text search for a keyword using elastic search
             curl -i http://apis.colav.co/scienti/product?apikey=XXXX&model_year=2022&institution=udea&search="machine learning"
+            # Text search by group given the group code
+            curl -i http://apis.colav.co/scienti/product?apikey=XXXX&model_year=2022&institution=udea&group_id=COL0008423
 
 
         """
@@ -134,12 +137,13 @@ class Scienti(HunabkuPluginBase):
             model_year = self.request.args.get('model_year')
             institution = self.request.args.get('institution')
             keyword = self.request.args.get('search')
+            group_id = self.request.args.get('group_id')
 
             response = self.check_required_parameters(self.request.args)
             if response is not None:
                 return response
             response = self.check_parameters(
-                ['apikey', 'COD_RH', 'COD_PRODUCTO', 'SGL_CATEGORIA', 'model_year', 'institution', 'search'], self.request.args.keys())
+                ['apikey', 'COD_RH', 'COD_PRODUCTO', 'SGL_CATEGORIA', 'model_year', 'institution', 'search', 'group_id'], self.request.args.keys())
             if response is not None:
                 return response
 
@@ -236,6 +240,16 @@ class Scienti(HunabkuPluginBase):
                         mimetype='application/json'
                     )
                     return response
+                if group_id:
+                    data = list(self.db["product"].find(
+                        {'group.COD_ID_GRUPO': group_id}, {"_id": 0}))
+                    response = self.app.response_class(
+                        response=self.json.dumps(data),
+                        status=200,
+                        mimetype='application/json'
+                    )
+                    return response
+
                 data = {
                     "error": "Bad Request", "message": "invalid parameters, please select the right combination of parameters."}
                 response = self.app.response_class(

--- a/HunabKu_scienti/hunabku_scienti/endpoints/Scienti.py
+++ b/HunabKu_scienti/hunabku_scienti/endpoints/Scienti.py
@@ -1,7 +1,6 @@
 from hunabku.HunabkuBase import HunabkuPluginBase, endpoint
 from hunabku.Config import Config, Param
 from pymongo import MongoClient
-from elasticsearch import Elasticsearch
 from elasticsearch import Elasticsearch, __version__ as es_version
 from elasticsearch_dsl import Search
 import sys
@@ -189,8 +188,8 @@ class Scienti(HunabkuPluginBase):
                     body = {
                         "query": {
                             "multi_match": {
-                                "query":    keyword,
-                                "type":     "phrase_prefix",
+                                "query": keyword,
+                                "type": "phrase_prefix",
                                 "fields": ["TXT_NME_PROD",
                                            "TXT_RESUMEN_PROD",
                                            "TXT_OBSERV_PROD",

--- a/HunabKu_scienti/hunabku_scienti/endpoints/Scienti.py
+++ b/HunabKu_scienti/hunabku_scienti/endpoints/Scienti.py
@@ -524,6 +524,7 @@ class Scienti(HunabkuPluginBase):
         @apiParam {String} SGL_CATEGORIA  category of the network
         @apiParam {String} model_year  year of the scienti model, example: 2022
         @apiParam {String} institution institution initials. supported example: udea, uec, unaula, univalle
+        @apiParam {String} search Allows to search text keywords in several fields of the patent collection using elastic search.
 
         @apiSuccess {Object}  Resgisters from MongoDB in Json format.
 
@@ -537,6 +538,9 @@ class Scienti(HunabkuPluginBase):
             curl -i http://apis.colav.co/scienti/event?apikey=XXXX&model_year=2022&institution=udea&COD_RH=0000000016&COD_EVENTO=2
             # An specific event category
             curl -i http://apis.colav.co/scienti/event?apikey=XXXX&model_year=2022&institution=udea&SGL_CATEGORIA=EC-EC_B
+            # Text search for a keyword using elastic search
+            curl -i http://apis.colav.co/scienti/event?apikey=XXXX&model_year=2022&institution=udea&search="machine learning"
+
         """
         if self.valid_apikey():
             cod_rh = self.request.args.get('COD_RH')
@@ -544,12 +548,13 @@ class Scienti(HunabkuPluginBase):
             sgl_cat = self.request.args.get('SGL_CATEGORIA')
             model_year = self.request.args.get('model_year')
             institution = self.request.args.get('institution')
+            keyword = self.request.args.get('search')
 
             response = self.check_required_parameters(self.request.args)
             if response is not None:
                 return response
             response = self.check_parameters(
-                ['apikey', 'COD_RH', 'COD_PROYECTO', 'COD_EVENTO', 'model_year', 'institution'], self.request.args.keys())
+                ['apikey', 'COD_RH', 'COD_PROYECTO', 'COD_EVENTO', 'model_year', 'institution', 'search'], self.request.args.keys())
             if response is not None:
                 return response
 
@@ -589,7 +594,49 @@ class Scienti(HunabkuPluginBase):
                         mimetype='application/json'
                     )
                     return response
+                if keyword:
+                    es_index = f'scienti_{institution}_{model_year}_event'
 
+                    body = {
+                        "query": {
+                            "multi_match": {
+                                "query": keyword,
+                                "type": "phrase_prefix",
+                                "fields": ["TXT_NME_EVENTO",
+                                           "TXT_RESUMEN_EVENTO",
+                                           "TXT_ACTIVIDADES",
+                                           "project.TXT_NME_PROYECTO",
+                                           "project.TXT_RESUMEN_PROYECTO",
+                                           "details.product.TXT_NME_PROD",
+                                           "details.product.TXT_RESUMEN_PROD",
+                                           "details.product.TXT_OBSERV_PROD",
+                                           "details.product.DSC_PROJETO",
+                                           "details.keywords.TXT_NME_PALABRA_CLAVE",
+                                           "details.application_sector.TXT_NME_SECTOR_APLIC",  # recursive 2 times
+                                           "details.application_sector.application_sector.TXT_NME_SECTOR_APLIC",
+                                           ]
+                            },
+                        }
+                    }
+                    # get the start time
+                    st = time.time()
+                    s = Search(using=self.es, index=es_index)
+                    s = s.update_from_dict(body)
+                    s = s.extra(track_total_hits=True)
+                    s.execute()
+                    data = [hit.to_dict() for hit in s.scan()]
+                    # get the end time
+                    et = time.time()
+                    # get the execution time
+                    elapsed_time = et - st
+                    print(f'Search for "{keyword}" Execution time:',
+                          elapsed_time, 'seconds')
+                    response = self.app.response_class(
+                        response=self.json.dumps(data),
+                        status=200,
+                        mimetype='application/json'
+                    )
+                    return response
                 data = {
                     "error": "Bad Request", "message": "invalid parameters, please select the right combination of parameters"}
                 response = self.app.response_class(

--- a/HunabKu_scienti/hunabku_scienti/endpoints/Scienti.py
+++ b/HunabKu_scienti/hunabku_scienti/endpoints/Scienti.py
@@ -107,7 +107,7 @@ class Scienti(HunabkuPluginBase):
         @apiParam {String} model_year  Year of the scienti model, example: 2022
         @apiParam {String} institution Institution initials. supported example: udea, uec, unaula, univalle
         @apiParam {String} search Allows to search text keywords in several fields of the product collection using elastic search.
-        @apiParam {String} group_id  Group id.
+        @apiParam {String} group_id  Returns products for the given group id.
 
 
         @apiSuccess {Object}  Resgisters from MongoDB in Json format.
@@ -124,7 +124,7 @@ class Scienti(HunabkuPluginBase):
             curl -i http://apis.colav.co/scienti/product?apikey=XXXX&model_year=2022&institution=udea&SGL_CATEGORIA=ART-ART_A1
             # Text search for a keyword using elastic search
             curl -i http://apis.colav.co/scienti/product?apikey=XXXX&model_year=2022&institution=udea&search="machine learning"
-            # Text search by group given the group code
+            # return products for the given group id
             curl -i http://apis.colav.co/scienti/product?apikey=XXXX&model_year=2022&institution=udea&group_id=COL0008423
 
 
@@ -449,6 +449,7 @@ class Scienti(HunabkuPluginBase):
         @apiParam {String} model_year  year of the scienti model, example: 2022
         @apiParam {String} institution institution initials. supported example: udea, uec, unaula, univalle
         @apiParam {String} search Allows to search text keywords in several fields of the project collection using elastic search.
+        @apiParam {String} group_id  Returns projects for the given group id.
 
         @apiSuccess {Object}  Resgisters from MongoDB in Json format.
 
@@ -464,6 +465,9 @@ class Scienti(HunabkuPluginBase):
             curl -i http://apis.colav.co/scienti/project?apikey=XXXX&model_year=2022&institution=udea&SGL_CATEGORIA=PID-00
             # Text search for a keyword using elastic search
             curl -i http://apis.colav.co/scienti/project?apikey=XXXX&model_year=2022&institution=udea&search="machine learning"
+            # return projects for the given group id
+            curl -i http://apis.colav.co/scienti/project?apikey=XXXX&model_year=2022&institution=udea&group_id=COL0008423
+
         """
 
         if self.valid_apikey():
@@ -473,12 +477,13 @@ class Scienti(HunabkuPluginBase):
             model_year = self.request.args.get('model_year')
             institution = self.request.args.get('institution')
             keyword = self.request.args.get('search')
+            group_id = self.request.args.get('group_id')
 
             response = self.check_required_parameters(self.request.args)
             if response is not None:
                 return response
             response = self.check_parameters(
-                ['apikey', 'COD_RH', 'COD_PROYECTO', 'SGL_CATEGORIA', 'model_year', 'institution', 'search'], self.request.args.keys())
+                ['apikey', 'COD_RH', 'COD_PROYECTO', 'SGL_CATEGORIA', 'model_year', 'institution', 'search', 'group_id'], self.request.args.keys())
             if response is not None:
                 return response
 
@@ -558,6 +563,17 @@ class Scienti(HunabkuPluginBase):
                         mimetype='application/json'
                     )
                     return response
+
+                if group_id:
+                    data = list(self.db["project"].find(
+                        {'group.COD_ID_GRUPO': group_id}, {"_id": 0}))
+                    response = self.app.response_class(
+                        response=self.json.dumps(data),
+                        status=200,
+                        mimetype='application/json'
+                    )
+                    return response
+
                 data = {
                     "error": "Bad Request", "message": "invalid parameters, please select the right combination of parameters"}
                 response = self.app.response_class(

--- a/HunabKu_scienti/hunabku_scienti/endpoints/Scienti.py
+++ b/HunabKu_scienti/hunabku_scienti/endpoints/Scienti.py
@@ -703,8 +703,8 @@ class Scienti(HunabkuPluginBase):
                     body = {
                         "query": {
                             "multi_match": {
-                                "query":    keyword,
-                                "type":     "phrase_prefix",
+                                "query": keyword,
+                                "type": "phrase_prefix",
                                 "fields": ["TXT_NME_PATENTE",
                                            "details.technical.product.TXT_NME_PROD",
                                            "details.technical.product.TXT_RESUMEN_PROD",

--- a/HunabKu_scienti/setup.py
+++ b/HunabKu_scienti/setup.py
@@ -85,7 +85,7 @@ def main():
             'hunabku',
             'pymongo',
             'elasticsearch>=7.0.0',
-            'elasticsearch-dsl>=7.0.0' #there is not release for es 8 yet, but it works.
+            'elasticsearch-dsl>=7.0.0'  # there is not release for es 8 yet, but it works.
         ],
     )
 

--- a/HunabKu_scienti/setup.py
+++ b/HunabKu_scienti/setup.py
@@ -83,7 +83,9 @@ def main():
             'flask>=1.1.2',
             'requests>=2.22.0',
             'hunabku',
-            'pymongo'
+            'pymongo',
+            'elasticsearch>=7.0.0',
+            'elasticsearch-dsl>=7.0.0' #there is not release for es 8 yet, but it works.
         ],
     )
 


### PR DESCRIPTION
With a plan to consolidate the packages that we have in a stable version for data capture and endpoints for apis.colav.co,
I am doing an effort to integrate Elastic Search into our packages.

Elastic Search is a powerful and useful component that we need in our processes for text search, those developments will allow us to have a very professional API for apis.colav.co and it will help us to trace the path for the implementation for impactu. 

Elastic Search was already containerized in our package Chia for DevOps  take a look at this PR https://github.com/colav-playground/Chia/pull/2
and deployed in the could service colav.co.

The package kerana (Under development and we have a lot of requirements not developed yet) will allow us to move the fields we need from MongoDB to elastic search. With the basic prototype we have I created the indices for scienti in elastic  search for the entities:

```
yellow open scienti_udea_2022_product   m1z8H-TlTTKseypgEkkxrw 1 1 390012 0   2.6gb   2.6gb
yellow open scienti_uec_2022_patent     j0G2kc59R2qmNc1gikgkAQ 1 1     10 0 121.5kb 121.5kb
yellow open scienti_uec_2022_network    G8nhoNHARyqlwaSasH_V0Q 1 1    312 0   3.1mb   3.1mb
yellow open scienti_ual_2023_product    eNZL-438TiuwHGSnMjI4-g 1 1  15908 0   110mb   110mb
yellow open scienti_uec_2022_event      _xfxagtpTjuAQz70StCQHQ 1 1  14808 0  74.1mb  74.1mb
yellow open scienti_udea_2022_network   -rMod2x7QAyRCogRAcYtZQ 1 1   1880 0  17.8mb  17.8mb
yellow open scienti_udea_2022_patent    7N6QaWYQTn-65TmAbiBFgA 1 1    448 0   3.9mb   3.9mb
yellow open scienti_uec_2022_project    f26WsI7hTg2a6ta30As_cA 1 1   8506 0  79.3mb  79.3mb
yellow open scienti_ual_2023_event      G_xTmRJKTf2qskipMLAHvw 1 1   4826 0  32.7mb  32.7mb
yellow open scienti_udea_2022_event     y4gai5XjTQe_N9SXRukHbQ 1 1 126300 0 657.7mb 657.7mb
yellow open scienti_uec_2022_product    PFftz9oLQ8-u6naH5AwjnQ 1 1  64561 0 517.6mb 517.6mb
yellow open scienti_ual_2023_network    fa_0gambSM2rBUAWEXcYNg 1 1    168 0   3.3mb   3.3mb
yellow open scienti_ual_2023_patent     FnMd_3MgSqmH6l4mX6NaTg 1 1      0 0    225b    225b
yellow open scienti_ual_2023_project    jfowjP3CS7iCkoN7K6hqaQ 1 1   1670 0  21.6mb  21.6mb
yellow open scienti_udea_2022_project   7IS-8JFCRG67kRQ7EnqiXA 1 1  55336 0 484.6mb 484.6mb
```
 
Still missing the indexes for Univalle in Elastic Search, it will be added soon.

This PR will allows :
- [x] search=keywork  ##all possible fields by entity
  -  [x] product 
  -  [x] project 
  -  [x] patent
  -  [x] event
  -  [x] network
- [x] group_id=COL0008423
  -  [x] product 
  -  [x] project 
  -  [&cross;] patent (not possible, there is no table for relation in gruplac, should it be through products?)
  -  [x] event
  -  [x] network

What means "all possible fields by entity"?
to optimize the search on ES, I need to study the fields by the entity, to select the strategy ones for the search in the case of a general search.
 